### PR TITLE
feat: introduce pinact-action for GitHub Actions version pinning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,9 @@ jobs:
   deps:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4.1.0
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+      - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: '.node-version'
           cache: 'pnpm'
@@ -22,9 +22,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [deps]
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4.1.0
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+      - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: '.node-version'
           cache: 'pnpm'
@@ -35,9 +35,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [deps]
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4.1.0
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+      - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: '.node-version'
           cache: 'pnpm'
@@ -48,9 +48,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [deps]
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4.1.0
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+      - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: '.node-version'
           cache: 'pnpm'
@@ -61,9 +61,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [deps]
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4.1.0
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+      - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: '.node-version'
           cache: 'pnpm'
@@ -73,14 +73,14 @@ jobs:
       - name: Run component tests with VRT
         run: pnpm test
       - name: Upload Screenshots
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()
         with:
           name: component-screenshots
           path: screenshots/
           retention-days: 30
       - name: Visual Regression Test
-        uses: reg-viz/reg-actions@v2
+        uses: reg-viz/reg-actions@480d59a2a63da144e914883346f5120f27701310 # v2
         with:
           github-token: '${{ secrets.GITHUB_TOKEN }}'
           image-directory-path: './screenshots'

--- a/.github/workflows/pinact.yml
+++ b/.github/workflows/pinact.yml
@@ -1,0 +1,24 @@
+name: Pinact
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  pinact:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pinact
+        uses: suzuki-shunsuke/pinact-action@d735505f3decf76fca3fdbb4c952e5b3eba0ffdd # v0.1.2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+


### PR DESCRIPTION
## Summary

- Add pinact-action to automatically pin GitHub Actions to commit hashes
- Update existing CI workflow actions from tags to commit hashes
- Enhance security and reproducibility of CI/CD pipeline

## Changes

### New Files
- `.github/workflows/pinact.yml` - Workflow to automatically pin actions on PRs

### Modified Files  
- `.github/workflows/ci.yml` - Updated all actions to use commit hashes instead of tags

## Security Benefits

1. **Supply Chain Protection**: Prevents malicious tag updates by using immutable commit hashes
2. **Reproducible Builds**: Ensures exact same action versions across all runs
3. **Automated Management**: pinact-action will automatically update and pin new actions

## Test Plan

- [ ] Verify pinact workflow runs successfully on this PR
- [ ] Confirm CI workflow still passes with pinned actions
- [ ] Test that new PRs trigger pinact-action correctly
- [ ] Validate commit hash updates work as expected

The pinact-action will automatically manage action versions going forward, eliminating manual hash lookups while maintaining security best practices.