### PR TITLE
fix: use site.url for consistent URL generation instead of localhost

### DIFF
--- a/app/islands/Share.tsx
+++ b/app/islands/Share.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useMemo } from 'hono/jsx';
 import { XIcon, HatenaIcon, PocketIcon, FeedlyIcon } from '../../components/icons';
+import { site } from '../../lib/config';
 
 type ShareButtonProps = {
   href: string;
@@ -50,7 +51,7 @@ type Props = {
 };
 
 export default function Share({ title, url: urlProp }: Props) {
-  const url = useMemo(() => new URL(urlProp), [urlProp]);
+  const url = useMemo(() => new URL(urlProp, site.url), [urlProp]);
 
   const encoded = useMemo(
     () => ({

--- a/app/routes/[year]/[slug].tsx
+++ b/app/routes/[year]/[slug].tsx
@@ -7,6 +7,7 @@ import { CodeCopyScript } from '../../../components/CodeCopyScript';
 import { Article } from '../../../components/Article';
 import { TwitterWidgetsScript } from '../../../components/TwitterWidgetsScript';
 import Share from '../../islands/Share';
+import { site } from '../../../lib/config';
 import type { HonoContext } from '../../global';
 
 const handler = async (c: HonoContext) => {
@@ -35,15 +36,15 @@ const handler = async (c: HonoContext) => {
     // Get previous and next posts
     const { previous, next } = await getPreviousAndNextPosts(fullSlug);
 
-    const currentUrl = new URL(`/${fullSlug}`, c.req.url).toString();
+    const currentUrl = new URL(`/${fullSlug}`, site.url).toString();
 
     // OGP settings
     const meta = {
       title: `${post.title} - wadackel.me`,
       url: currentUrl,
       image: post.image
-        ? new URL(post.image, c.req.url).toString()
-        : new URL(`/${fullSlug}/ogp.png`, c.req.url).toString(),
+        ? new URL(post.image, site.url).toString()
+        : new URL(`/${fullSlug}/ogp.png`, site.url).toString(),
       description: post.excerpt || '',
     };
 

--- a/app/routes/_renderer.tsx
+++ b/app/routes/_renderer.tsx
@@ -58,7 +58,7 @@ export default jsxRenderer(({ children }, c) => {
             <meta property="og:url" content={currentUrl} />
             <meta property="og:title" content={title || site.title} />
             {description && <meta property="og:description" content={description} />}
-            <meta property="og:image" content={new URL('/ogp.png', currentUrl).toString()} />
+            <meta property="og:image" content={new URL('/ogp.png', site.url).toString()} />
             <meta property="og:site_name" content={site.title} />
             <meta name="twitter:card" content="summary_large_image" />
             <meta name="twitter:site" content={`@${site.social.x}`} />
@@ -76,7 +76,7 @@ export default jsxRenderer(({ children }, c) => {
           rel="alternate"
           type="application/rss+xml"
           title={site.title}
-          href={new URL('/rss.xml', currentUrl).toString()}
+          href={new URL('/rss.xml', site.url).toString()}
         />
         <meta name="theme-color" content="#fff" />
 

--- a/app/routes/rss.xml.tsx
+++ b/app/routes/rss.xml.tsx
@@ -3,7 +3,7 @@ import { getAllPosts } from '../../lib/posts';
 import { site } from '../../lib/config';
 
 export default async function RSS(c: Context) {
-  const baseUrl = 'https://blog.wadackel.me';
+  const baseUrl = site.url;
   const lastBuildDate = new Date().toUTCString();
 
   // All posts

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -5,7 +5,7 @@ import { XIcon, GitHubIcon, FeedlyIcon, RssIcon } from './icons';
 export const Footer = () => {
   const year = new Date().getFullYear();
   const feed = '/rss.xml';
-  const feedEncoded = encodeURIComponent(`${site.title}/rss.xml`);
+  const feedEncoded = encodeURIComponent(`${site.url}/rss.xml`);
 
   return (
     <footer class="flex justify-center items-center h-footer text-white bg-[url('/footer-bg.jpg')] bg-[length:95px] antialiased">

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -1,6 +1,7 @@
 export const site = {
   lang: 'ja-JP',
   title: 'wadackel.me',
+  url: 'https://blog.wadackel.me',
   description:
     'wadackel.me は、わだ つよし (@wadackel) の技術×プライベートなブログです。ダックスフンド is かわいい。',
   social: {


### PR DESCRIPTION
## Summary
- Add site.url configuration for centralized URL management  
- Fix Share.tsx URL generation to prevent localhost URLs in production
- Update RSS feed, OGP meta tags, and Footer to use consistent URLs

## Test plan
- [x] Verify Share buttons generate correct URLs in production
- [x] Check RSS feed URLs are correct
- [x] Confirm OGP meta tags use proper absolute URLs  
- [x] Test Footer Feedly link uses site.url