### PR TITLE
chore: update scaffdog templates and improve HonoX JSX type safety

### DIFF
--- a/.scaffdog/1.post-entry.md
+++ b/.scaffdog/1.post-entry.md
@@ -1,6 +1,6 @@
 ---
 name: 'post-entry'
-root: 'src/pages'
+root: 'content'
 output: '.'
 questions:
   name: 'Please enter a entry name (e.g. "hello-world")'

--- a/.scaffdog/2.component-ui.md
+++ b/.scaffdog/2.component-ui.md
@@ -1,12 +1,11 @@
 ---
 name: 'component-ui'
-root: 'src/components'
+root: 'components'
 output:
   - '*'
   - '**/internal'
 ignore:
   - '**/{A..Z}*'
-  - '**/__tests__'
 questions:
   name: 'Please enter a component name'
 ---
@@ -15,31 +14,18 @@ questions:
 
 - component: `{{ inputs.name | pascal }}`
 
-# `{{ inputs.name | pascal }}/index.ts`
+# `{{ component }}.tsx`
 
 ```typescript
-export * from './{{ component }}';
-```
+import { Child } from 'hono/jsx';
 
-# `{{ component }}/{{ component }}.module.css`
+type Props = {
+  children: string
+};
 
-```css
-.wrapper {
-  /* TODO */
-}
-```
-
-# `{{ component }}/{{ component }}.tsx`
-
-```typescript
-import React from 'react';
-import styles from './{{ component }}.module.css';
-
-export type Props = {};
-
-export const {{ component }}: React.FC<Props> = ({ children }) => {
+export const {{ component }} = ({ children }: Props) => {
   return (
-    <div className={styles.wrapper}>{children}</div>
+    <div class="text-md">{children}</div>
   );
 };
 ```

--- a/app/islands/Share.tsx
+++ b/app/islands/Share.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'hono/jsx';
+import { Child, useCallback, useMemo } from 'hono/jsx';
 import { XIcon, HatenaIcon, PocketIcon, FeedlyIcon } from '../../components/icons';
 import { site } from '../../lib/config';
 
@@ -6,7 +6,7 @@ type ShareButtonProps = {
   href: string;
   'aria-label': string;
   title?: string;
-  children: unknown;
+  children: Child;
   'data-name'?: string;
   'data-width'?: string;
   'data-height'?: string;

--- a/components/Pagination.tsx
+++ b/components/Pagination.tsx
@@ -1,10 +1,11 @@
+import { Child } from 'hono/jsx';
 import { ArrowLeftIcon, ArrowRightIcon } from './icons';
 
 type PaginationItemProps = {
   href?: string;
   ariaLabel: string;
   disabled: boolean;
-  children: any;
+  children: Child;
 };
 
 const PaginationItem = ({ href, ariaLabel, disabled, children }: PaginationItemProps) => {

--- a/components/PostContent.tsx
+++ b/components/PostContent.tsx
@@ -1,5 +1,7 @@
+import { Child } from 'hono/jsx';
+
 type Props = {
-  children: unknown;
+  children: Child;
 };
 
 export const PostContent = ({ children }: Props) => {


### PR DESCRIPTION
## Summary

- Updated scaffdog templates to match current HonoX project structure
- Fixed component template to use proper HonoX conventions instead of React patterns
- Improved JSX type safety by replacing generic `unknown` and `any` children types with proper `Child` type from `hono/jsx`

## Changes

### Scaffdog Templates
- Updated `post-entry` template root from `src/pages` to `content` 
- Updated `component-ui` template root from `src/components` to `components`
- Simplified component template to use HonoX JSX patterns instead of React
- Removed React-specific imports and CSS modules usage

### Type Safety Improvements
- Import and use `Child` type from `hono/jsx` for component children props
- Updated `Share.tsx`, `Pagination.tsx`, and `PostContent.tsx` to use proper JSX children typing

## Test plan

- [x] Scaffdog templates generate correctly structured files
- [x] TypeScript compilation passes with improved type safety
- [x] Components render correctly with proper JSX children handling